### PR TITLE
chore: update dependency illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.4.0",
     "evandarwin/jsend": "1.2.*",
-    "illuminate/support": "~5.0"
+    "illuminate/support": "^6"
   },
   "require-dev": {
     "orchestra/testbench": "~3.0",


### PR DESCRIPTION
The existing package 5.5 is to low for Laravel 6